### PR TITLE
Bump scikit-image from 0.16.2 to 0.22.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+.idea
 checkpoints/*
+__pycache__/
+results/

--- a/lib/mesh_util.py
+++ b/lib/mesh_util.py
@@ -42,7 +42,7 @@ def reconstruction(net, cuda, calib_tensor,
 
     # Finally we do marching cubes
     try:
-        verts, faces, normals, values = measure.marching_cubes_lewiner(sdf, 0.5)
+        verts, faces, normals, values = measure.marching_cubes(sdf, 0.5)
         # transform verts into world coordinate system
         verts = np.matmul(mat[:3, :3], verts.T) + mat[:3, 3:4]
         verts = verts.T

--- a/lib/sdf.py
+++ b/lib/sdf.py
@@ -55,8 +55,8 @@ def eval_grid_octree(coords, eval_func,
 
     sdf = np.zeros(resolution)
 
-    dirty = np.ones(resolution, dtype=np.bool)
-    grid_mask = np.zeros(resolution, dtype=np.bool)
+    dirty = np.ones(resolution, dtype=bool)
+    grid_mask = np.zeros(resolution, dtype=bool)
 
     reso = resolution[0] // init_resolution
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ PyOpenGL==3.1.5
 pyparsing==2.4.6
 python-dateutil==2.8.1
 PyWavelets==1.1.1
-scikit-image==0.16.2
+scikit-image==0.22.0
 scipy==1.4.1
 Shapely==1.7.0
 six==1.14.0


### PR DESCRIPTION
Just to fix deprecated function: scikit-image measure.marching_cubes_lewiner